### PR TITLE
Fix potential issues uncovered by compiler warnings

### DIFF
--- a/utility/BTimerDefs.cpp
+++ b/utility/BTimerDefs.cpp
@@ -22,9 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "wiring_private.h"
 #include "../PWM.h"
-
-#define UINT16_MAX 65535
-#define UINT8_MAX 255
+#include <stdint.h>
 
 //--------------------------------------------------------------------------------
 //							Helper Functions
@@ -377,6 +375,7 @@ float GetPinResolution(uint8_t pin)
 			break;
 		case TIMER2B:
 			top = Timer2_GetTop();
+			break;
 		default:
 			return 0;
 	}


### PR DESCRIPTION
- Fix potential issue due to implicit fallthrough and thus returning 0
- Fix potential issue due to redefinition of MAX Values that are already defined in stdint.h